### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,11 +36,11 @@ jobs:
       HTTPBIN_URL: http://localhost
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Start local httpbin
         run: docker run -d -p 80:80 --name httpbin kennethreitz/httpbin
       - name: Wait for httpbin to be ready
@@ -57,7 +57,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(; path = pwd())); Pkg.instantiate();'
       - name: Build and deploy
@@ -83,7 +83,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EasyCurl"
 uuid = "5dc68c43-2cae-45c1-9c9f-30d6e2b9e002"
-version = "4.3.1"
+version = "4.3.2"
 
 [deps]
 LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"

--- a/src/EasyCurl.jl
+++ b/src/EasyCurl.jl
@@ -144,7 +144,7 @@ function CurlDiagnostics(curl::CurlClient)
         _get_typedinfo(Cdouble, curl, CURLINFO_TOTAL_TIME),
         _get_typedinfo(Cdouble, curl, CURLINFO_CONNECT_TIME),
         _get_typedinfo(Cdouble, curl, CURLINFO_APPCONNECT_TIME),
-        _get_typedinfo(Cdouble, curl, CURLINFO_NAMELOOKUP_TIME)
+        _get_typedinfo(Cdouble, curl, CURLINFO_NAMELOOKUP_TIME),
     )
 end
 

--- a/src/protocols/HTTP.jl
+++ b/src/protocols/HTTP.jl
@@ -44,7 +44,7 @@ const HTTP_VERSION_MAP = Dict{UInt64,String}(
     CURL_HTTP_VERSION_1_1 => "1.1",
     CURL_HTTP_VERSION_2_0 => "2.0",
     CURL_HTTP_VERSION_2TLS => "2.0",
-    CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE => "2.0"
+    CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE => "2.0",
 )
 
 """
@@ -453,7 +453,7 @@ function http_request(
             version = req.options.version,
             connect_timeout = req.options.connect_timeout,
             read_timeout = req.options.read_timeout,
-            body_len = length(req.body)
+            body_len = length(req.body),
         )
         try
             perform_request(client, req)


### PR DESCRIPTION
## Summary
- Bump patch version 4.3.1 → 4.3.2
- Add trailing commas in multiline constructs (EasyCurl.jl, HTTP.jl)
- Bump julia-actions/setup-julia from 2 to 3
- Bump julia-actions/cache from 2 to 3
- Bump codecov/codecov-action from 5 to 6
- Bump actions/github-script from 8 to 9

Closes #47, closes #48, closes #49, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)