### PR TITLE
Fix badge URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EasyCurl.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://bhftbootcamp.github.io/EasyCurl.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://bhftbootcamp.github.io/EasyCurl.jl/dev)
-[![Build Status](https://github.com/bhftbootcamp/EasyCurl.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/bhftbootcamp/EasyCurl.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://bhftbootcamp.github.io/EasyCurl.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://bhftbootcamp.github.io/EasyCurl.jl/dev/)
+[![Build Status](https://github.com/bhftbootcamp/EasyCurl.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/bhftbootcamp/EasyCurl.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/bhftbootcamp/EasyCurl.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/bhftbootcamp/EasyCurl.jl)
 [![Registry](https://img.shields.io/badge/registry-General-4063d8)](https://github.com/JuliaRegistries/General)
 


### PR DESCRIPTION
## Summary
- Fix Build Status badge click-through URL: changed `query=branch%3Amain` to `query=branch%3Amaster` to match the default branch
- Add trailing slashes to Stable and Dev docs badge URLs (`/stable` -> `/stable/`, `/dev` -> `/dev/`) for consistency with other bhftbootcamp repos

## Test plan
- [x] Verify Build Status badge links to the correct `master` branch filter
- [x] Verify Stable docs badge URL ends with `/stable/`
- [x] Verify Dev docs badge URL ends with `/dev/`